### PR TITLE
Verse ical import is server dependent

### DIFF
--- a/F5/single-server-session-iRule.tcl
+++ b/F5/single-server-session-iRule.tcl
@@ -147,7 +147,8 @@ when HTTP_REQUEST {
           (($path contains ".nsf")
           or ($path contains "/verse/userinfo")
           or ($path contains "/verse/checksession")
-          or ($path contains "/verse/userredirectinfo"))
+          or ($path contains "/verse/userredirectinfo")
+          or ($path contains "/verse/ical"))
           and !($tentativeNSFPath contains "Forms9.nsf")
       } {
         set isPoolDependentRequest 1


### PR DESCRIPTION
ical import needs to be performed on a server that hosts the NSF into which the import is taking place.