### PR TITLE
Ensure that hex parsing maintains expected number of characters

### DIFF
--- a/F5/single-server-session-iRule.tcl
+++ b/F5/single-server-session-iRule.tcl
@@ -113,8 +113,8 @@ when HTTP_REQUEST {
     set authPool [lindex $fields 0]
     set encodedAuthMemberIP [lindex $fields 1]
     set authPoolMemberPort [expr [lindex $fields 2]/256]
-    set hexDecodedIP [format %X $encodedAuthMemberIP]
-    scan $hexDecodedIP "%2x%2x%2x%2x" l m n o
+    set hexDecodedIP [format %08X $encodedAuthMemberIP]
+    scan $hexDecodedIP "%02x%02x%02x%02x" l m n o
     set decodedAuthMemberIP "$o.$n.$m.$l"
     pool $authPool member $decodedAuthMemberIP $authPoolMemberPort
     call logger "REQ" $requestedURI "using pool, ip, port: $authPool $decodedAuthMemberIP $authPoolMemberPort"

--- a/F5/single-server-session-iRule.tcl
+++ b/F5/single-server-session-iRule.tcl
@@ -116,8 +116,9 @@ when HTTP_REQUEST {
     set hexDecodedIP [format %08X $encodedAuthMemberIP]
     scan $hexDecodedIP "%02x%02x%02x%02x" l m n o
     set decodedAuthMemberIP "$o.$n.$m.$l"
+    call logger "REQ" $requestedURI "using ip, port: $decodedAuthMemberIP $authPoolMemberPort"
     pool $authPool member $decodedAuthMemberIP $authPoolMemberPort
-    call logger "REQ" $requestedURI "using pool, ip, port: $authPool $decodedAuthMemberIP $authPoolMemberPort"
+    call logger "REQ" $requestedURI "using pool: $authPool"
     set targetPool $authPool
   } else {
     ##### 1.b We are NOT in the middle of authentication against a Domino server


### PR DESCRIPTION
Fix issue where authentication requests made by the iRule were targeting an incorrect server IP address